### PR TITLE
Display font immediately using a system font

### DIFF
--- a/src/scss/functions/_font-face.scss
+++ b/src/scss/functions/_font-face.scss
@@ -23,5 +23,6 @@
     src: $src;
     font-weight: $font-weight;
     font-style: $font-style;
+    font-display: swap;
   }
 }


### PR DESCRIPTION
To avoid invisible text during font loading

*related: https://web.dev/avoid-invisible-text/